### PR TITLE
Fix Kakfa brokers port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ zookeeper:
 
 
 kafka1:
-  image: samsara/kafka 
+  image: samsara/kafka
   ports:
     - "9092:9092"
     - "15002:15000"
@@ -25,28 +25,30 @@ kafka1:
 
 
 kafka2:
-  image: samsara/kafka 
+  image: samsara/kafka
   ports:
-    - "9093:9092"
+    - "9093:9093"
     - "15003:15000"
   links:
     - zookeeper:zookeeper
   environment:
     KAFKA_BROKER_ID: 2
+    KAFKA_BROKER_BROKER: 9093
   volumes:
     - /tmp/docker/kafka2/logs:/logs
     - /tmp/docker/kafka2/data:/data
 
 
 kafka3:
-  image: samsara/kafka 
+  image: samsara/kafka
   ports:
-    - "9094:9092"
+    - "9094:9094"
     - "15004:15000"
   links:
     - zookeeper:zookeeper
   environment:
     KAFKA_BROKER_ID: 3
+    KAFKA_BROKER_PORT: 9094
   volumes:
     - /tmp/docker/kafka3/logs:/logs
     - /tmp/docker/kafka3/data:/data


### PR DESCRIPTION
After the PR submitted to the [samsara](https://github.com/samsara/samsara-docker-images) repository related to the docker Kafka image has been accepted, now is possible to specify a different port for each broker in order to make possible the connectivity with all the brokers in environments that don't support Docker natively. 

If we don't specify a different port for each broker Zookeeper will give to the consumer the following information:
  broker 3 at 172.17.0.11:9092
  broker 2 at 172.17.0.9:9092
  broker 1 at 172.17.0.7:9092
This leads to a connection error from the client side because inside of the virtual-machine that host the docker server only one IP is associated with the port 9092. 

This PR is intended to avoid this situation by specifying a different port for each broker. 