### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ for local development and experimentation.
 
 0. Install [Docker Toolbox][docker-toolbox]
 
-    brew install docker-machine
-
 :memo: You will need to carry out this [routing stepup step](./OSX-Routing.md)
 now and every time you reload your routing table or restart the OS.
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,99 @@
 # Kafka Development Environment
-This repository gives you the ability to create a local kafka cluster for development and experimentation (NOT production)
+
+This repository gives you the ability to create a local [Kafka][kafka] cluster
+for local development and experimentation.
 
 ##  Setup
-1. Install [docker](https://docs.docker.com/installation/#installation) onto your system 
-2. Install [docker-compose](https://docs.docker.com/compose/install/)
-3. Download [Confluent Platform](http://confluent.io/downloads/) zip file and unzip in a location of your choice, you'll need this mainly for the kafka command/console tools
-4. Osx users will need to carry out this [routing stepup step](./OSX-Routing.md) now and every time they restart their system. (Currently looking for a better solution)
 
-##  Running 
-0. This step only applies to linux users, mac users should skip this. you'll need to create local directories (under /tmp/docker) that are linked to directories internally used by the containers. set up all associated local volumes/directories by running this command  
-``mkdir -p `grep /tmp/docker docker-compose.yml | cut -d' ' -f6 | cut -d':' -f1 | sort` `` 
-0. Ensure docker is running (mac users follow these [steps](https://docs.docker.com/installation/mac/#from-your-command-line))
-0. You may need to run ``eval "$(docker-machine env default)"``
-0. Start all the needed containers.run ``docker-compose up -d``
-0. Running ``docker-compose ps`` or ``docker ps`` should show at least a zookeeper container and 1 or 3 kafka containers
+### Linux
+
+0. Install `docker` via your distribution's package manager.
+0. Download and install [Docker Compose][docker-compose].
+0. Download and install the [Confluent Platform][confluent-platform].
+
+### OS X
+
+NB: You will need to have [Homebrew][homebrew] installed.
+
+0. Install [Docker Machine][docker-machine]
+
+    brew install docker-machine
+
+0. Install [Kafka][kafka]
+
+    brew install kafka
+
+0. Install [Zookeeper][zookeeper]
+
+    brew install kafka
+
+0. You will need to carry out this [routing stepup step](./OSX-Routing.md) now
+   and every time you reload your routing table or restart the OS.
+
+## Running
+
+### Linux
+
+0. You'll need to create local directories (under `/tmp/docker`) that are linked
+   to directories internally used by the containers. Set up all associated local
+   volumes/directories by running this command:
+
+    mkdir -p `grep /tmp/docker docker-compose.yml | cut -d' ' -f6 | cut -d':' -f1 | sort`
+
+### General
+
+0. Start all the needed containers by running:
+
+    docker-compose up -d
+
+0. Running `docker-compose ps` or `docker ps` should show at least 1 Zookeeper
+   container and 1 or 3 Kafka containers.
 
 ##  Walkthroughs
-These walkthroughs are aimed at getting you familiar with kafka.    
-They are written with the aim of getting different groups (devs, admins) comfortable using kafka.   
+
+These walkthroughs are aimed at getting you familiar with Kafka. They are
+written with the aim of getting different audiences (developers, system
+administrators) comfortable using Kafka.
 
 0. [**Basic Walkthrough**](./walkthroughs/basic_walkthrough/README.md) - Aimed at everyone and *everyone* should go through this.
 0. **Ruby Walkthrough** - TODO
 0. **Clojure Walkthrough** - TODO
 
-##  Stopping
-To stop all the containers running ``docker-compose stop``   
-To remove all the containers ``docker-compose rm``  
+## Container controls
+
+You can control the running "composed" containers as follows:
+
+* Stop all the containers:
+
+    docker-compose stop
+
+* Remove all the containers:
+
+    docker-compose rm`
 
 ##  Notes
-0. Currently the zookeeper and kafka containers use volumes that are on the local filesystem for Linux, but for Macs are inside the boot2docker vm (type `boot2docker ssh` and explore /tmp/docker). These volumes will survive container restarts and should be deleted (and recreated for linux users) if you want your containers to start with clean volumes.
-0. If you need to repoint the docker-compose.yml soft link, please shutdown and remove the current configuration first ``docker-compose stop && docker-compose rm``
+
+0. Currently the Zookeeper and Kafka containers use volumes that are on the
+   local filesystem for Linux, but for OS X are inside the `boot2docker` vm
+   (type `boot2docker ssh` and explore `/tmp/docker`). These volumes will
+   survive container restarts and should be deleted (and recreated for Linux
+   users) if you want your containers to start with clean volumes.
+0. If you need to repoint the `docker-compose.yml` soft link, please shutdown
+   and remove the current configuration first by running:
+
+    docker-compose stop && docker-compose rm
 
 ##  TODO
 
-0. Expose/link the configuration directories of zookeeper and kafka containers the same way the logs and data directories are exposed. This will allow people to further experiment with various configurations
+0. Add a monitoring docker (Already have the perfect candidate)
+0. Expose/link the configuration directories of Zookeeper and Kafka containers
+   the same way the logs and data directories are exposed. This will allow
+   people to further experiment with various configurations.
 0. Explore using a data/volume container instead of volumes linked to local disk.
+
+[confluent-platform]: http://www.confluent.io/developer#download
+[docker-compose]: http://docs.docker.com/compose/install/
+[docker-toolbox]: https://www.docker.com/docker-toolbox
+[homebrew]: http://brew.sh
+[kafka]: http://kafka.apache.org
+[zookeeper]: http://zookeeper.apache.org/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ NB: You will need to have [Homebrew][homebrew] installed.
    to directories internally used by the containers. Set up all associated local
    volumes/directories by running this command:
 
-    mkdir -p `grep /tmp/docker docker-compose.yml | cut -d' ' -f6 | cut -d':' -f1 | sort`
+    mkdir -p `grep /tmp/docker docker-compose.yml | awk '{split($2, array, ":")}; {print array[1]}'`
 
 ### General
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ for local development and experimentation.
 
 ### OS X
 
-NB: You will need to have [Homebrew][homebrew] installed.
+:warning: You will need to have [Homebrew][homebrew] installed.
 
 0. Install [Docker Toolbox][docker-toolbox]
 
     brew install docker-machine
 
-0. You will need to carry out this [routing stepup step](./OSX-Routing.md) now
-   and every time you reload your routing table or restart the OS.
+:memo: You will need to carry out this [routing stepup step](./OSX-Routing.md)
+now and every time you reload your routing table or restart the OS.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ for local development and experimentation.
 
 NB: You will need to have [Homebrew][homebrew] installed.
 
-0. Install [Docker Machine][docker-machine]
+0. Install [Docker Toolbox][docker-toolbox]
 
     brew install docker-machine
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ for local development and experimentation.
 
 ##  Setup
 
+0. Download and install the [Confluent Platform][confluent-platform].
+
 ### Linux
 
 0. Install `docker` via your distribution's package manager.
 0. Download and install [Docker Compose][docker-compose].
-0. Download and install the [Confluent Platform][confluent-platform].
 
 ### OS X
 
@@ -18,14 +19,6 @@ NB: You will need to have [Homebrew][homebrew] installed.
 0. Install [Docker Toolbox][docker-toolbox]
 
     brew install docker-machine
-
-0. Install [Kafka][kafka]
-
-    brew install kafka
-
-0. Install [Zookeeper][zookeeper]
-
-    brew install kafka
 
 0. You will need to carry out this [routing stepup step](./OSX-Routing.md) now
    and every time you reload your routing table or restart the OS.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ now and every time you reload your routing table or restart the OS.
 
     docker-compose up -d
 
-0. Running `docker-compose ps` or `docker ps` should show at least 1 Zookeeper
-   container and 1 or 3 Kafka containers.
+0. Running `docker-compose ps` or `docker ps` should show at least 1
+   [Zookeeper][zookeeper] container and 1 or 3 Kafka containers.
 
 ##  Walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ You can control the running "composed" containers as follows:
 ##  Notes
 
 0. Currently the Zookeeper and Kafka containers use volumes that are on the
-   local filesystem for Linux, but for OS X are inside the `boot2docker` vm
-   (type `boot2docker ssh` and explore `/tmp/docker`). These volumes will
-   survive container restarts and should be deleted (and recreated for Linux
-   users) if you want your containers to start with clean volumes.
+   local filesystem for Linux, but for OS X are inside the Docker Machine VM
+   (type `docker-machine ls` to find your machine, then `docker-machine ssh
+   <machine>` and explore `/tmp/docker`). These volumes will survive container
+   restarts and should be deleted (and recreated for Linux users) if you want
+   your containers to start with clean volumes.
 0. If you need to repoint the `docker-compose.yml` soft link, please shutdown
    and remove the current configuration first by running:
 


### PR DESCRIPTION
:information_desk_person: [Docker Machine](https://docker.com/machine) was released for OS X earlier this year and has replaced `boot2docker` as the preferred method of running Docker on OS X. These changes update the instructions in the README to support this.