### PR TITLE
Update readme to refer to docker machine instead of boot2docker

### DIFF
--- a/OSX-Routing.md
+++ b/OSX-Routing.md
@@ -1,23 +1,22 @@
 #  Set up Routing (For Mac users only)
 ## The Issue
-The minimal os, boot2docker, is used by osx to run docker containers. It runs as a VM on your box and then runs the docker engine/host.  
-The exposed container ports can still be reached by going to the VM's ip (run `boot2docker ip`), but the issue is that Kafka nodes use a hostname/ip address to advertised themselves, this advertised address is what clients use to send and consume messages.  
+The minimal os, boot2docker managed by docker-machine, is used by osx to run docker containers. It runs as a VM on your box and then runs the docker engine/host.
+The exposed container ports can still be reached by going to the VM's ip (run `docker-image ip default`), but the issue is that Kafka nodes use a hostname/ip address to advertised themselves, this advertised address is what clients use to send and consume messages.
 Containers within boot2docker end up with ip addresses that aren't reachable from the host/local machine, this stops clients outside of the boot2docker vm from sending/consuming to and from the actual Kafka Nodes.
-## The Solution (not perfect but good enough) 
-For mac users to use the kafka node hostname/ip addesses, we'll need to route the subnet ip range that the docker containers are using to the boot2docker vm ip (remember we are exposing the container ports on this ip already).  
-You'll need to carry out the following steps  
-1) Find out the boot2docker vm's ip by running ``boot2docker ip``   
-2) Find out the subnet range being used by the containers, by running ``docker ps | cut -d' ' -f1 | tail -n +2 | xargs -I {} docker inspect --format '{{.Config.Image }} {{ .NetworkSettings.IPAddress }}' {}``  
+## The Solution (not perfect but good enough)
+For mac users to use the kafka node hostname/ip addesses, we'll need to route the subnet ip range that the docker containers are using to the boot2docker vm ip (remember we are exposing the container ports on this ip already).
+You'll need to carry out the following steps
+1) Find out the boot2docker vm's ip by running ``docker-machine ip default``
+2) Find out the subnet range being used by the containers, by running ``docker ps | cut -d' ' -f1 | tail -n +2 | xargs -I {} docker inspect --format '{{.Config.Image }} {{ .NetworkSettings.IPAddress }}' {}``
 You should see a bunch of image names and ips like
-> samsara/kafka:latest 172.17.0.8  
-> samsara/kafka:latest 172.17.0.7  
-> samsara/kafka:latest 172.17.0.6  
-> samsara/zookeeper:latest 172.17.0.5  
+> samsara/kafka:latest 172.17.0.8
+> samsara/kafka:latest 172.17.0.7
+> samsara/kafka:latest 172.17.0.6
+> samsara/zookeeper:latest 172.17.0.5
 
-3) Check for any existing routing rules by running ``netstat -rn | grep 172.17``   
-4) If a rule exists, just make sure you can reach the container ips and any ports.   
-5) If a rule doesn't exist, create one by running ``sudo route -n add 172.17.0.0/24 $(boot2docker ip)``. Then check you can reach the container ips and ports; if you are running docker machine then you may wish to run ``sudo route -n add 172.17.0.0/24 $(docker-machine ip default)``
+3) Check for any existing routing rules by running ``netstat -rn | grep 172.17``
+4) If a rule exists, just make sure you can reach the container ips and any ports.
+5) If a rule doesn't exist, create one by running ``sudo route -n add 172.17.0.0/24 $(docker-machine ip default)``. Then check you can reach the container ips and ports; if you are running docker machine then you may wish to run ``sudo route -n add 172.17.0.0/24 $(docker-machine ip default)``
 
-To remove a routing rule run ``sudo route -n delete 172.17.0.0/24 $(boot2docker ip)``   
-The above routing rule is temporary, so it will need to be re-created if the system is restarted.  
-
+To remove a routing rule run ``sudo route -n delete 172.17.0.0/24 $(docker-machine ip default)``
+The above routing rule is temporary, so it will need to be re-created if the system is restarted.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To stop all the containers running ``docker-compose stop``
 To remove all the containers ``docker-compose rm``  
 
 ##  Notes
-0. Currently the zookeeper and kafka containers use volumes that are on the local filesystem for Linux, but for Macs are inside the boot2docker vm (type `boot2docker ssh` and explore /tmp/docker). These volumes will survive container restarts and should be deleted (and recreated for linux users) if you want your containers to start with clean volumes.
+0. Currently the zookeeper and kafka containers use volumes that are on the local filesystem for Linux, but for Macs are inside the docker-machine vm (type `docker-machine ssh default` and explore /tmp/docker). These volumes will survive container restarts and should be deleted (and recreated for linux users) if you want your containers to start with clean volumes.
 0. If you need to repoint the docker-compose.yml soft link, please shutdown and remove the current configuration first ``docker-compose stop && docker-compose rm``
 
 ##  TODO

--- a/README.md
+++ b/README.md
@@ -1,37 +1,101 @@
 # Kafka Development Environment
-This repository gives you the ability to create a local kafka cluster for development and experimentation (NOT production)
+This repository gives you the ability to create a local [Kafka][kafka] cluster for local development and experimentation.
 
 ##  Setup
-1. Install [docker](https://docs.docker.com/installation/#installation) onto your system 
-2. Install [docker-compose](https://docs.docker.com/compose/install/)
-3. Download [Confluent Platform](http://confluent.io/downloads/) zip file and unzip in a location of your choice, you'll need this mainly for the kafka command/console tools
-4. Osx users will need to carry out this [routing stepup step](./OSX-Routing.md) now and every time they restart their system. (Currently looking for a better solution)
+0. Download and install the [Confluent Platform][confluent-platform].
 
-##  Running 
-0. This step only applies to linux users, mac users should skip this. you'll need to create local directories (under /tmp/docker) that are linked to directories internally used by the containers. set up all associated local volumes/directories by running this command  
-``mkdir -p `grep /tmp/docker docker-compose.yml | cut -d' ' -f6 | cut -d':' -f1 | sort` `` 
-0. Ensure docker is running (mac users follow these [steps](https://docs.docker.com/installation/mac/#from-your-command-line))
-0. You may need to run ``eval "$(docker-machine env default)"``
-0. Start all the needed containers.run ``docker-compose up -d``
-0. Running ``docker-compose ps`` or ``docker ps`` should show at least a zookeeper container and 1 or 3 kafka containers
+### Linux
+
+1. Install `docker` via your distribution's package manager.
+0. Download and install [Docker Compose][docker-compose].
+
+### OS X
+
+:warning: You will need to have [Homebrew][homebrew] installed.
+
+1. Install docker machine running
+
+   `brew install docker-machine`
+
+    Docker machine is also part of the [Docker Toolbox][docker-toolbox].
+
+0. List docker machines running
+
+    `docker-machine ls`
+
+0. Create vm for docker containers if you do not have any running
+
+    `docker-machine create --driver virtualbox default`
+
+    :note: This tutorial uses virtual machine with name `default`, but it can be replaced by other.
+
+0. It is necessary to route virtual machines subnet ip range to be able to reach docker advertised ports. Follow [routing setup step](./OSX-Routing.md) every time you reload your routing table or restart the OS.
+
+## Running
+
+### Linux
+
+0. You'll need to create local directories (under `/tmp/docker`) that are linked
+   to directories internally used by the containers. Set up all associated local
+   volumes/directories by running this command:
+
+    `mkdir -p grep /tmp/docker docker-compose.yml | awk '{split($2, array, ":")}; {print array[1]}`
+
+### General
+
+1. Start all the needed containers by running:
+
+    `docker-compose up -d`
+
+0. Running `docker-compose ps` or `docker ps` should show at least 1 Zookeeper
+   container and 1 or 3 Kafka containers.
 
 ##  Walkthroughs
-These walkthroughs are aimed at getting you familiar with kafka.    
-They are written with the aim of getting different groups (devs, admins) comfortable using kafka.   
 
-0. [**Basic Walkthrough**](./walkthroughs/basic_walkthrough/README.md) - Aimed at everyone and *everyone* should go through this.
+These walkthroughs are aimed at getting you familiar with Kafka. They are
+written with the aim of getting different audiences (developers, system
+administrators) comfortable using Kafka.
+
+1. [**Basic Walkthrough**](./walkthroughs/basic_walkthrough/README.md) - Aimed at everyone and *everyone* should go through this.
 0. **Ruby Walkthrough** - TODO
 0. **Clojure Walkthrough** - TODO
 
-##  Stopping
-To stop all the containers running ``docker-compose stop``   
-To remove all the containers ``docker-compose rm``  
+## Container controls
+
+You can control the running "composed" containers as follows:
+
+* Stop all the containers:
+
+    `docker-compose stop`
+
+* Remove all the containers:
+
+    `docker-compose rm`
 
 ##  Notes
-0. Currently the zookeeper and kafka containers use volumes that are on the local filesystem for Linux, but for Macs are inside the docker-machine vm (type `docker-machine ssh default` and explore /tmp/docker). These volumes will survive container restarts and should be deleted (and recreated for linux users) if you want your containers to start with clean volumes.
-0. If you need to repoint the docker-compose.yml soft link, please shutdown and remove the current configuration first ``docker-compose stop && docker-compose rm``
+
+1. Currently the Zookeeper and Kafka containers use volumes that are on the
+   local filesystem for Linux, but for OS X are inside the Docker Machine VM
+   (type `docker-machine ls` to find your machine, then `docker-machine ssh
+   <machine>` and explore `/tmp/docker`). These volumes will survive container
+   restarts and should be deleted (and recreated for Linux users) if you want
+   your containers to start with clean volumes.
+0. If you need to repoint the `docker-compose.yml` soft link, please shutdown
+   and remove the current configuration first by running:
+
+    docker-compose stop && docker-compose rm
 
 ##  TODO
 
-0. Expose/link the configuration directories of zookeeper and kafka containers the same way the logs and data directories are exposed. This will allow people to further experiment with various configurations
+1. Add a monitoring docker (Already have the perfect candidate)
+0. Expose/link the configuration directories of Zookeeper and Kafka containers
+   the same way the logs and data directories are exposed. This will allow
+   people to further experiment with various configurations.
 0. Explore using a data/volume container instead of volumes linked to local disk.
+
+[confluent-platform]: http://www.confluent.io/developer#download
+[docker-compose]: http://docs.docker.com/compose/install/
+[docker-toolbox]: https://www.docker.com/docker-toolbox
+[homebrew]: http://brew.sh
+[kafka]: http://kafka.apache.org
+[zookeeper]: http://zookeeper.apache.org/

--- a/walkthroughs/basic_walkthrough/README.md
+++ b/walkthroughs/basic_walkthrough/README.md
@@ -1,168 +1,168 @@
 # Basic Kafka Walkthrough
-This walkthrough deals with getting a complete kafka newbie familiar with some of the concepts around kafka.  
-One thing to note is, this walkthrough is mainly targetted at Osx users, linux users can also follow this walkthrough but will need to substitute ``$(boot2docker ip)`` with ``localhost`` in all the commands.  
+This walkthrough deals with getting a complete kafka newbie familiar with some of the concepts around kafka.
+One thing to note is, this walkthrough is mainly targetted at Osx users, linux users can also follow this walkthrough but will need to substitute ``$(docker-machine ip default)`` with ``localhost`` in all the commands. [Docker machine](https://docs.docker.com/machine/get-started/) manages virtual machines on which docker contains run. This tutorial assumes that `default` docker machine is used. However it can be substitute with any machine.
 
+To create a new docker machine run
+
+``docker-machine create --driver virtualbox default``
 
 ##  Pre-requisite
 The reader should have followed the instructions outlayed in the [main readme](../../README.md) and should have a full 3 node kafka cluster up and running
 
 ## Topics
-A kafka topic is made up of partitions, with each partition containing a sequence of messages that are sent to it.  
-The partition that each message is sent to, is detemined by the message key. If a key isn't provided, then the default kafka producer will randomly pick a partition and send messages to it (for a default of 10 mins)  
-If a key is provided then, the key will be hashed to determine a partition and the message will be sent to the partition, thus messages with the same key will always end up in the same order in the same partition.  
-It is possible to have a topic with just one partition, however this is not advisable for topics that will have a high volume of messages as this limits how much you can parallize the processing  
+A kafka topic is made up of partitions, with each partition containing a sequence of messages that are sent to it.
+The partition that each message is sent to, is detemined by the message key. If a key isn't provided, then the default kafka producer will randomly pick a partition and send messages to it (for a default of 10 mins)
+If a key is provided then, the key will be hashed to determine a partition and the message will be sent to the partition, thus messages with the same key will always end up in the same order in the same partition.
+It is possible to have a topic with just one partition, however this is not advisable for topics that will have a high volume of messages as this limits how much you can parallize the processing
 
-#### 1. Create a Topic  
-Go to the bin directory where you downloaded and extracted confluent package to run  
-``./kafka-topics --zookeeper $(boot2docker ip):2181 --create --topic benders --partitions 3 --replication-factor 3`` 
-*"Note $(docker-machine ip default) if using dockermachine"*
+#### 1. Create a Topic
+Go to the bin directory where you downloaded and extracted confluent package to run
+``./kafka-topics --zookeeper $(docker-machine ip default):2181 --create --topic benders --partitions 3 --replication-factor 3``
 
-   This should create a topic with 3 partitions with each partition having 3 copies.   
-#### 2. View Topic information  
-To view the list of topics, run  
-``./kafka-topics --zookeeper $(boot2docker ip):2181 --list``   
-*"Note $(docker-machine ip default) if using dockermachine"*
+   This should create a topic with 3 partitions with each partition having 3 copies.
+#### 2. View Topic information
+To view the list of topics, run
+``./kafka-topics --zookeeper $(docker-machine ip default):2181 --list``
 
-   This will return something similar to the following (*ignore the _schema topic, it's auto-created by the schemaregistry container*)  
+   This will return something similar to the following (*ignore the _schema topic, it's auto-created by the schemaregistry container*)
    > benders
 
-To view more detailed information about the topic (Partitions, Partition leaders, Replicas, In Sync Replica Set) run  
-``./kafka-topics --zookeeper $(boot2docker ip):2181 --describe``  
-*"Note $(docker-machine ip default) if using dockermachine"*
+To view more detailed information about the topic (Partitions, Partition leaders, Replicas, In Sync Replica Set) run
+``./kafka-topics --zookeeper $(docker-machine ip default):2181 --describe``
 
    This will return something similar to the following
-   > Topic:benders	PartitionCount:3	ReplicationFactor:3	Configs:  
-   >	Topic: benders	Partition: 0	Leader: 2	Replicas: 2,3,1	Isr: 2,3,1  
-   >    Topic: benders	Partition: 1	Leader: 3	Replicas: 3,1,2	Isr: 3,1,2  
-   >    Topic: benders	Partition: 2	Leader: 1	Replicas: 1,2,3	Isr: 1,2,3  
+   > Topic:benders	PartitionCount:3	ReplicationFactor:3	Configs:
+   >	Topic: benders	Partition: 0	Leader: 2	Replicas: 2,3,1	Isr: 2,3,1
+   >    Topic: benders	Partition: 1	Leader: 3	Replicas: 3,1,2	Isr: 3,1,2
+   >    Topic: benders	Partition: 2	Leader: 1	Replicas: 1,2,3	Isr: 1,2,3
 
-   This essentially means the following (for Partition 0 on the second line)  
-   - The leader for partition 0 is broker 2  
-   - There are 3 copies for partition 0, with the copies residing on brokers 2, 3 and 1  
-   - All three copies of partition 0 are up to date and are said to be in ISR (In Sync Replica Set)  
-   Note The leader for a partition is the broker that all client reads and writes are carried out with. The other brokers only keep up with the leader for that partition and won't handle external client read/write requests  
+   This essentially means the following (for Partition 0 on the second line)
+   - The leader for partition 0 is broker 2
+   - There are 3 copies for partition 0, with the copies residing on brokers 2, 3 and 1
+   - All three copies of partition 0 are up to date and are said to be in ISR (In Sync Replica Set)
+   Note The leader for a partition is the broker that all client reads and writes are carried out with. The other brokers only keep up with the leader for that partition and won't handle external client read/write requests
 
 ## Sending messages
-We are going to use Kafka's own java console producer to send the messages to kafka cluster.   
-This producer takes a list of brokers and uses this list to get meta-data about all the topics in the cluster.   
-This meta-data contains information about the all the topic partitions, but most importantly which broker is the leader for each partition at this moment in time.  
-The producer by default will hash any provided message keys, calculate the modulus (using the number of partition) to determine which partiton to sent the message to, then use the meta-data to know which broker to send the message(s) to.  
-If no message key is provided, it will send the message(s) to a randomly chosen partition and send continously for a certain period.   
-*Please bear in mind, this is how the java producer used by the console tool behaves, not necessarily how other producers behave*  
+We are going to use Kafka's own java console producer to send the messages to kafka cluster.
+This producer takes a list of brokers and uses this list to get meta-data about all the topics in the cluster.
+This meta-data contains information about the all the topic partitions, but most importantly which broker is the leader for each partition at this moment in time.
+The producer by default will hash any provided message keys, calculate the modulus (using the number of partition) to determine which partiton to sent the message to, then use the meta-data to know which broker to send the message(s) to.
+If no message key is provided, it will send the message(s) to a randomly chosen partition and send continously for a certain period.
+*Please bear in mind, this is how the java producer used by the console tool behaves, not necessarily how other producers behave*
 
 #### 1. Send Messages (to non-specific partitions)
-Run  
-`` echo '{"name":"Ang", "skills":["fire-bending", "water-bending", "earth-bending", "air-bending"]}' | ./kafka-console-producer --broker-list $(boot2docker ip):9092 --topic benders``  
-`` echo '{"name":"Korra", "skills":["fire-bending", "water-bending", "earth-bending", "air-bending"]}' | ./kafka-console-producer --broker-list $(boot2docker ip):9092 --topic benders``  
+Run
+`` echo '{"name":"Ang", "skills":["fire-bending", "water-bending", "earth-bending", "air-bending"]}' | ./kafka-console-producer --broker-list $(docker-machine ip default):9092 --topic benders``
+`` echo '{"name":"Korra", "skills":["fire-bending", "water-bending", "earth-bending", "air-bending"]}' | ./kafka-console-producer --broker-list $(docker-machine ip default):9092 --topic benders``
 
-Since we didn't provide any keys, these messages will end up on any partition. Luckily we can run a command to consume messages from all partitions, so to see these messages run  
-``./kafka-console-consumer --zookeeper $(boot2docker ip):2181 --topic benders --from-beginning``  
-This will consume messages from all partitions from the beginnning (and will continue to consume), you should see something similar to this  
-> {"name":"Ang", "skills":["fire-bending", "water-bending", "earth-bending", "air-bending"]}  
-> {"name":"Korra", "skills":["fire-bending", "water-bending", "earth-bending", "air-bending"]}  
+Since we didn't provide any keys, these messages will end up on any partition. Luckily we can run a command to consume messages from all partitions, so to see these messages run
+``./kafka-console-consumer --zookeeper $(docker-machine ip default):2181 --topic benders --from-beginning``
+This will consume messages from all partitions from the beginnning (and will continue to consume), you should see something similar to this
+> {"name":"Ang", "skills":["fire-bending", "water-bending", "earth-bending", "air-bending"]}
+> {"name":"Korra", "skills":["fire-bending", "water-bending", "earth-bending", "air-bending"]}
 
 
 #### 2. Send Messages (to Specific partitions)
-*Please note the extra properties passed to the console-producer command (--property)*  
-Run  
-``./kafka-console-producer --property parse.key=true --property key.separator="--" --broker-list $(boot2docker ip):9092 --topic benders``  
-Now enter the following lines  
-``1--{"name":"Zuko", "skills":["fire-bending"]}``  
-``1--{"name":"Azula", "skills":["fire-bending"]}``  
-``1--{"name":"Mako", "skills":["fire-bending"]}``  
-``2--{"name":"Toph Beifong", "skills":["earth-bending"]}``  
-``2--{"name":"Bolin", "skills":["earth-bending"]}``  
-``3--{"name":"Katara", "skills":["water-bending"]}``  
-``3--{"name":"Kya", "skills":["water-bending"]}``  
+*Please note the extra properties passed to the console-producer command (--property)*
+Run
+``./kafka-console-producer --property parse.key=true --property key.separator="--" --broker-list $(docker-machine ip default):9092 --topic benders``
+Now enter the following lines
+``1--{"name":"Zuko", "skills":["fire-bending"]}``
+``1--{"name":"Azula", "skills":["fire-bending"]}``
+``1--{"name":"Mako", "skills":["fire-bending"]}``
+``2--{"name":"Toph Beifong", "skills":["earth-bending"]}``
+``2--{"name":"Bolin", "skills":["earth-bending"]}``
+``3--{"name":"Katara", "skills":["water-bending"]}``
+``3--{"name":"Kya", "skills":["water-bending"]}``
 
-Hit Control-C to stop sending messages.  
-What should have happened is that the entries with the same key (number) will have ended up in the same partitions, in the order that they were entered.  
-Thus all the fire,water and earth benders should end up on their own partitions.   
-*Don't be suprised if you see Ang and Korra on any of the partitions as they were sent without any keys and can appear any where, again bear in mind this is the default behaviour of the java kafka producer*   
+Hit Control-C to stop sending messages.
+What should have happened is that the entries with the same key (number) will have ended up in the same partitions, in the order that they were entered.
+Thus all the fire,water and earth benders should end up on their own partitions.
+*Don't be suprised if you see Ang and Korra on any of the partitions as they were sent without any keys and can appear any where, again bear in mind this is the default behaviour of the java kafka producer*
 
 
 ## Consuming messages
-As you've probably guessed by now, we can consume messages from all a Topic's partitions or from a specific partition.  
+As you've probably guessed by now, we can consume messages from all a Topic's partitions or from a specific partition.
 
-#### Consume messages from all partitions   
-To consume all the messages that have been sent to all the partitions of the bender topic run   
-``./kafka-console-consumer --property print.key=true --zookeeper $(boot2docker ip):2181 --topic benders --from-beginning``  
+#### Consume messages from all partitions
+To consume all the messages that have been sent to all the partitions of the bender topic run
+``./kafka-console-consumer --property print.key=true --zookeeper $(docker-machine ip default):2181 --topic benders --from-beginning``
 *This console consumer implementation will read the partitions in no specific order, but the order of the messages with the same key should be maintained (run the command multiple times to better understand)*
 
-#### Consume messages from particular partitions   
-*Please note the extra property passed to the console-consumer command (--property)*  
-To consume all the messages that have been sent to partition 0 of the bender topic run   
-``./kafka-run-class kafka.tools.SimpleConsumerShell --property print.key=true --broker-list "$(boot2docker ip):9092" --topic benders --partition 0 --offset -2``  
+#### Consume messages from particular partitions
+*Please note the extra property passed to the console-consumer command (--property)*
+To consume all the messages that have been sent to partition 0 of the bender topic run
+``./kafka-run-class kafka.tools.SimpleConsumerShell --property print.key=true --broker-list "$(docker-machine ip default):9092" --topic benders --partition 0 --offset -2``
 
-To consume all the messages that have been sent to partition 1 of the bender topic run   
-``./kafka-run-class kafka.tools.SimpleConsumerShell --property print.key=true--broker-list "$(boot2docker ip):9092" --topic benders --partition 1 --offset -2``  
+To consume all the messages that have been sent to partition 1 of the bender topic run
+``./kafka-run-class kafka.tools.SimpleConsumerShell --property print.key=true--broker-list "$(docker-machine ip default):9092" --topic benders --partition 1 --offset -2``
 
-To consume all the messages that have been sent to partition 2 of the bender topic run   
-``./kafka-run-class kafka.tools.SimpleConsumerShell --property print.key=true--broker-list "$(boot2docker ip):9092" --topic benders --partition 2 --offset -2``  
+To consume all the messages that have been sent to partition 2 of the bender topic run
+``./kafka-run-class kafka.tools.SimpleConsumerShell --property print.key=true--broker-list "$(docker-machine ip default):9092" --topic benders --partition 2 --offset -2``
 
 
 ## Balancing Partitions.
 Kafka aims to balance the partitions and partition leaders (default configuration) evenly across the brokers.
-To see this in action, we are going to shut down a broker, look at how kafka rebalances and then bring the broker back up.   
-1) Stop Broker 3 by running ``docker-compose stop kafka3``  
-   After the broker has been stopped, view the partitions by running ``/kafka-topics --zookeeper $(boot2docker ip):2181 --describe``  
-   You should see something similar to the following  
-   > Topic:benders	PartitionCount:3	ReplicationFactor:3	Configs:  
-   >	Topic: benders	Partition: 0	Leader: 1	Replicas: 3,1,2	Isr: 1,2  
-   >	Topic: benders	Partition: 1	Leader: 1	Replicas: 1,2,3	Isr: 1,2  
-   >	Topic: benders	Partition: 2	Leader: 2	Replicas: 2,3,1	Isr: 2,1  
+To see this in action, we are going to shut down a broker, look at how kafka rebalances and then bring the broker back up.
+1) Stop Broker 3 by running ``docker-compose stop kafka3``
+   After the broker has been stopped, view the partitions by running ``/kafka-topics --zookeeper $(docker-machine ip default):2181 --describe``
+   You should see something similar to the following
+   > Topic:benders	PartitionCount:3	ReplicationFactor:3	Configs:
+   >	Topic: benders	Partition: 0	Leader: 1	Replicas: 3,1,2	Isr: 1,2
+   >	Topic: benders	Partition: 1	Leader: 1	Replicas: 1,2,3	Isr: 1,2
+   >	Topic: benders	Partition: 2	Leader: 2	Replicas: 2,3,1	Isr: 2,1
 
-   As can be seen from the above, Broker 1 is the leader for partitions 0 and 1, whilst Broker 2 is the leader for only partition2  
-   It can also be seen that each partition doesn't have a full ISR (i.e all replicas are not in the ISR)  
-   Also the cluster can still function in this state, but with the possibility that Broker 1 will be dealing with twice the load/traffic that Broker 2 will be dealing with.  
-   Send another message by running ``echo '1--{"name":"Iroh", "skills":["fire-bending"]}' | ./kafka-console-producer --property parse.key=true --property key.separator="--"  --broker-list $(boot2docker ip):9092 --topic benders``  
-   Now re-run the previous consuming commands, you should see Iroh when consuming all partitions or just the partition that the fire benders are on.  
+   As can be seen from the above, Broker 1 is the leader for partitions 0 and 1, whilst Broker 2 is the leader for only partition2
+   It can also be seen that each partition doesn't have a full ISR (i.e all replicas are not in the ISR)
+   Also the cluster can still function in this state, but with the possibility that Broker 1 will be dealing with twice the load/traffic that Broker 2 will be dealing with.
+   Send another message by running ``echo '1--{"name":"Iroh", "skills":["fire-bending"]}' | ./kafka-console-producer --property parse.key=true --property key.separator="--"  --broker-list $(docker-machine ip default):9092 --topic benders``
+   Now re-run the previous consuming commands, you should see Iroh when consuming all partitions or just the partition that the fire benders are on.
 
 2) Start Broker 3 by running ``docker-compose start kafka3``
-   After the broker has started, view the partitions again by running ``/kafka-topics --zookeeper $(boot2docker ip):2181 --describe``  
-   You'll need to give the kafka cluster some time (a few minutes) before it rebalances the partition leaders and you'll see something similar to the following  
-   > Topic:benders	PartitionCount:3	ReplicationFactor:3	Configs:  
-   >	Topic: benders	Partition: 0	Leader: 3	Replicas: 3,1,2	Isr: 1,2,3  
-   >	Topic: benders	Partition: 1	Leader: 1	Replicas: 1,2,3	Isr: 1,2,3  
-   >	Topic: benders	Partition: 2	Leader: 2	Replicas: 2,3,1	Isr: 2,1,3  
-   
-   The above output shows that all the ISR for all the partitions are full, but more importantly that each broker is now only responsible for just one partition  
+   After the broker has started, view the partitions again by running ``/kafka-topics --zookeeper $(docker-machine ip default):2181 --describe``
+   You'll need to give the kafka cluster some time (a few minutes) before it rebalances the partition leaders and you'll see something similar to the following
+   > Topic:benders	PartitionCount:3	ReplicationFactor:3	Configs:
+   >	Topic: benders	Partition: 0	Leader: 3	Replicas: 3,1,2	Isr: 1,2,3
+   >	Topic: benders	Partition: 1	Leader: 1	Replicas: 1,2,3	Isr: 1,2,3
+   >	Topic: benders	Partition: 2	Leader: 2	Replicas: 2,3,1	Isr: 2,1,3
+
+   The above output shows that all the ISR for all the partitions are full, but more importantly that each broker is now only responsible for just one partition
 
 
-## Useful Information  
-To find out the actual ips of all containers run   
-``docker ps | cut -d' ' -f1 | tail -n +2 | xargs -i {} docker inspect --format '{{.config.image }} {{ .networksettings.ipaddress }}' {}``  
-*In actuality these are the ip's that you should use in the following commands, but since we've exposed the ports to the docker host, we'll use the localhost for linux and $(boot2docker ip) for osx*
+## Useful Information
+To find out the actual ips of all containers run
+``docker ps | cut -d' ' -f1 | tail -n +2 | xargs -i {} docker inspect --format '{{.config.image }} {{ .networksettings.ipaddress }}' {}``
+*In actuality these are the ip's that you should use in the following commands, but since we've exposed the ports to the docker host, we'll use the localhost for linux and $(docker-machine ip default) for osx*
 ###  Kafka Commands
-- **Create a topic**   
-  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --create --topic test --partitions 1 --replication-factor 1``  
- you can experiment with the partition numbers and replication-factor  
- a personal rule of thumb is to have the number of partitions and replicas be multiples of the number of nodes 
+- **Create a topic**
+  ``./kafka-topics --zookeeper $(docker-machine ip default):2181 --create --topic test --partitions 1 --replication-factor 1``
+ you can experiment with the partition numbers and replication-factor
+ a personal rule of thumb is to have the number of partitions and replicas be multiples of the number of nodes
 
-- **List all available topics**   
-  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --list``  
+- **List all available topics**
+  ``./kafka-topics --zookeeper $(docker-machine ip default):2181 --list``
 
-- **Detailed list of topics, partitions and partition leaders**   
-  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --describe``   
+- **Detailed list of topics, partitions and partition leaders**
+  ``./kafka-topics --zookeeper $(docker-machine ip default):2181 --describe``
 
-- **Send a message to a topic**   
-  ``echo 'Fear is the mind killer' | ./kafka-console-producer --broker-list $(boot2docker ip):9092 --topic test``  
+- **Send a message to a topic**
+  ``echo 'Fear is the mind killer' | ./kafka-console-producer --broker-list $(docker-machine ip default):9092 --topic test``
 
-- **To send a bunch of messages (manually) via the console (press enter to send each message)**   
-  ``./kafka-console-producer --broker-list $(boot2docker ip):9092 --topic test``  
+- **To send a bunch of messages (manually) via the console (press enter to send each message)**
+  ``./kafka-console-producer --broker-list $(docker-machine ip default):9092 --topic test``
 
-- **To continuously consume the latest messages from a topic and all it's partitions**   
-  ``./kafka-console-consumer --zookeeper $(boot2docker ip):2181 --topic test``   
+- **To continuously consume the latest messages from a topic and all it's partitions**
+  ``./kafka-console-consumer --zookeeper $(docker-machine ip default):2181 --topic test``
 
-- **To consume ALL the messages from a topic and all it's partitions from the beginning**    
-  ``./kafka-console-consumer --zookeeper $(boot2docker ip):2181 --topic test --from-beginning``   
+- **To consume ALL the messages from a topic and all it's partitions from the beginning**
+  ``./kafka-console-consumer --zookeeper $(docker-machine ip default):2181 --topic test --from-beginning``
 
-- **To consume A message from A particular topic and A particular partition from the begining**   
-  ``./kafka-run-class kafka.tools.SimpleConsumerShell --broker-list "$(boot2docker ip):9092" --max-messages 1 --topic test --partition 0 --offset -2``  
+- **To consume A message from A particular topic and A particular partition from the begining**
+  ``./kafka-run-class kafka.tools.SimpleConsumerShell --broker-list "$(docker-machine ip default):9092" --max-messages 1 --topic test --partition 0 --offset -2``
 
-- **To consume A message from A particular topic and A particular partition from the latest**   
-  ``./kafka-run-class kafka.tools.SimpleConsumerShell --broker-list "$(boot2docker ip):9092" --max-messages 1 --topic test --partition 0 --offset -1``  
+- **To consume A message from A particular topic and A particular partition from the latest**
+  ``./kafka-run-class kafka.tools.SimpleConsumerShell --broker-list "$(docker-machine ip default):9092" --max-messages 1 --topic test --partition 0 --offset -1``
 
 ### Useful Kafka links
-*Remove the `.sh` part of the commands*  
-1) More Topic and partition tools [page](https://cwiki.apache.org/confluence/display/KAFKA/Replication+tools)  
+*Remove the `.sh` part of the commands*
+1) More Topic and partition tools [page](https://cwiki.apache.org/confluence/display/KAFKA/Replication+tools)

--- a/walkthroughs/migration_walkthrough/README.md
+++ b/walkthroughs/migration_walkthrough/README.md
@@ -1,45 +1,45 @@
 # Kafka Migration Walkthrough
-This walkthrough deals with the scenario where you have an existing kafka cluster (e.g 1 zookeeper node 3 kafka nodes)  
-And you are looking to add 3 new kafka nodes and decommission the 3 old kafka nodes.   
+This walkthrough deals with the scenario where you have an existing kafka cluster (e.g 1 zookeeper node 3 kafka nodes)
+And you are looking to add 3 new kafka nodes and decommission the 3 old kafka nodes.
 
 # Main Goal
-This walkthrough simulates how you would replace brokers with new ones using docker-compose, it is not *100% realistic* (as you are running containers locally) but it should give you a good grounding on what's involved. The aim is to get you comfortable with the process.   
+This walkthrough simulates how you would replace brokers with new ones using docker-compose, it is not *100% realistic* (as you are running containers locally) but it should give you a good grounding on what's involved. The aim is to get you comfortable with the process.
 
 
 ##  Pre-requisite
-- The reader should have followed the instructions outlayed in the SETUP section of [main readme](../../README.md)   
-  Please make sure you've carried out all the steps detailed in the SETUP section.   
-- You should have 2 terminals open. One in this project root for running the docker-compose commands, the other for running kafka commands  
+- The reader should have followed the instructions outlayed in the SETUP section of [main readme](../../README.md)
+  Please make sure you've carried out all the steps detailed in the SETUP section.
+- You should have 2 terminals open. One in this project root for running the docker-compose commands, the other for running kafka commands
 
 
 ## The Walkthrough
 
 ### 1) Bring up a 3 kafka node cluster with some topics
-- Go to the project's main directory and run  ``docker-compose -f configs/kafka-migration.yml  up -d``  
-- Confirm your cluster is up by running  ``docker-compose -f configs/kafka-migration.yml ps``   
-- Create a topic, by going to your kafka/confluent-kafka bin directory and running   
-  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --create --topic airbenders --partitions 3 --replication-factor 3``  
-  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --create --topic waterbenders --partitions 3 --replication-factor 3``  
-- Confirm the topics have been created by running  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --describe``  
+- Go to the project's main directory and run  ``docker-compose -f configs/kafka-migration.yml  up -d``
+- Confirm your cluster is up by running  ``docker-compose -f configs/kafka-migration.yml ps``
+- Create a topic, by going to your kafka/confluent-kafka bin directory and running
+  ``./kafka-topics --zookeeper $(docker-machine ip default):2181 --create --topic airbenders --partitions 3 --replication-factor 3``
+  ``./kafka-topics --zookeeper $(docker-machine ip default):2181 --create --topic waterbenders --partitions 3 --replication-factor 3``
+- Confirm the topics have been created by running  ``./kafka-topics --zookeeper $(docker-machine ip default):2181 --describe``
 
 
-### 2) Bring up 3 new additional Kafka nodes 
- - Edit the configs/kafka-migration.yml  and uncomment brokers 4 to 6  
- - Bring up the 3 new nodes by running  ``docker-compose -f configs/kafka-migration.yml  up -d --no-recreate  kafka4 kafka5 kafka6 ``    
+### 2) Bring up 3 new additional Kafka nodes
+ - Edit the configs/kafka-migration.yml  and uncomment brokers 4 to 6
+ - Bring up the 3 new nodes by running  ``docker-compose -f configs/kafka-migration.yml  up -d --no-recreate  kafka4 kafka5 kafka6 ``
  - Confirm your 6 node kafka cluster is up by running  ``docker-compose -f configs/kafka-migration.yml  ps``
 
 ### NOTE existing partitions aren't moved to new brokers
-- The new brokers are now part of the cluster BUT no partitions will reside on them. So essentially they are doing nothing.   
-  You can check this by running  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --describe``  
-- Create a new topic by running  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --create --topic earthbenders --partitions 3 --replication-factor 3``   
-- Some of the partitions in the new topic "earthbenders" will now end up on the new brokers (4, 5 or 6).  
-  But the partitions for airbender and waterbender topics will stil be on the old brokers (1, 2 and 3)  
-  Check by running  ``./kafka-topics --zookeeper $(boot2docker ip):2181 --describe``   
-- At this stage you'll have quite an unbalanced cluster with brokers 1, 2 and 3 doing most of the work  
+- The new brokers are now part of the cluster BUT no partitions will reside on them. So essentially they are doing nothing.
+  You can check this by running  ``./kafka-topics --zookeeper $(docker-machine default):2181 --describe``
+- Create a new topic by running  ``./kafka-topics --zookeeper $(docker-machine default):2181 --create --topic earthbenders --partitions 3 --replication-factor 3``
+- Some of the partitions in the new topic "earthbenders" will now end up on the new brokers (4, 5 or 6).
+  But the partitions for airbender and waterbender topics will stil be on the old brokers (1, 2 and 3)
+  Check by running  ``./kafka-topics --zookeeper $(docker-machine ip default):2181 --describe``
+- At this stage you'll have quite an unbalanced cluster with brokers 1, 2 and 3 doing most of the work
 
 ### 3) Move all topics onto the new brokers
 - To make sure all topics are now on the new brokers (4 5 6), you need to use the re-assign tool
-- Create a json file (topics-to-move.json) listing all the topics to be reassigned, something similar to the following  
+- Create a json file (topics-to-move.json) listing all the topics to be reassigned, something similar to the following
 ```
 {
     "topics":
@@ -49,33 +49,32 @@ This walkthrough simulates how you would replace brokers with new ones using doc
         "version": 1
 }
 ```
-- Run re-assign tool to generate all the partitions that need to be moved, do this by running   
-  ``./kafka-reassign-partitions --zookeeper $(boot2docker ip):2181 --topics-to-move-json-file topics-to-move.json --broker-list "4,5,6" --generate``  <- Note that we supply only the new brokers to --broker-list   
-- The above command will generate the 2 blocks of json, the first is the current partition assignments for the topics, whilst the second block is the partition assignment you want to achieve for the topics.   
-- Save the first block of json into a file called revert-partitions.json  and  save the second block of json into a file called reassign-partitions.json   
-- Now run the re-assign tool to move all the partitions to brokers 4 5 6, by running   
-``./kafka-reassign-partitions --zookeeper $(boot2docker ip):2181 --reassignment-json-file  reassign-partitions.json --execute``   
-- This above command will again output 2 blocks of json. The first being the current partition assigments and the second being the assignment you are trying to achieved. If you already haven't saved these blocks into different files, please do so now  
-- Verify the progress of the partition movement, as you can imagine depending on the amount of topics/partition/data this can take a while  
-  To verify the progress run the following command   
-  ``./kafka-reassign-partitions --zookeeper $(boot2docker ip):2181 --reassignment-json-file  ~/Documents/reassign-partitions.json --verify``   
-- **NOTE** Again you'll have to wait for all this to be completely done. And it might take a while.  
-  Producers and Consumers sending data will probably lose connections and have to reconnect as the various partition leaders that were being communicated to are moved from the old brokers to the new ones. Producers/Consumers should expect this anyways when talking to a kafka cluster and should be able to handle connection loss in a graceful way    
+- Run re-assign tool to generate all the partitions that need to be moved, do this by running
+  ``./kafka-reassign-partitions --zookeeper $(docker-machine ip default):2181 --topics-to-move-json-file topics-to-move.json --broker-list "4,5,6" --generate``  <- Note that we supply only the new brokers to --broker-list
+- The above command will generate the 2 blocks of json, the first is the current partition assignments for the topics, whilst the second block is the partition assignment you want to achieve for the topics.
+- Save the first block of json into a file called revert-partitions.json  and  save the second block of json into a file called reassign-partitions.json
+- Now run the re-assign tool to move all the partitions to brokers 4 5 6, by running
+``./kafka-reassign-partitions --zookeeper $(docker-machine ip default):2181 --reassignment-json-file  reassign-partitions.json --execute``
+- This above command will again output 2 blocks of json. The first being the current partition assigments and the second being the assignment you are trying to achieved. If you already haven't saved these blocks into different files, please do so now
+- Verify the progress of the partition movement, as you can imagine depending on the amount of topics/partition/data this can take a while
+  To verify the progress run the following command
+  ``./kafka-reassign-partitions --zookeeper $(docker-machine ip default):2181 --reassignment-json-file  ~/Documents/reassign-partitions.json --verify``
+- **NOTE** Again you'll have to wait for all this to be completely done. And it might take a while.
+  Producers and Consumers sending data will probably lose connections and have to reconnect as the various partition leaders that were being communicated to are moved from the old brokers to the new ones. Producers/Consumers should expect this anyways when talking to a kafka cluster and should be able to handle connection loss in a graceful way
 
 
 ### 4) Decommision/shutdown the old brokers
-- At this stage all the partitions should now be on brokers 4, 5 and 6. Confirm this by running  
-``./kafka-topics --zookeeper $(boot2docker ip):2181 --describe``   
-- You should NOT see any partitions on brokers 1 2 or 3   
-- Shutdown brokers 1 2 and 3 by running this command    
-  ``docker-compose -f configs/kafka-migration.yml  stop kafka1 kafka2 kafka3``   
+- At this stage all the partitions should now be on brokers 4, 5 and 6. Confirm this by running
+``./kafka-topics --zookeeper $(docker-machine ip default):2181 --describe``
+- You should NOT see any partitions on brokers 1 2 or 3
+- Shutdown brokers 1 2 and 3 by running this command
+  ``docker-compose -f configs/kafka-migration.yml  stop kafka1 kafka2 kafka3``
 - Congratulations!!! You have now decommissioned brokers 1 2 3, replaced them with brokers 4 5 6 and moved all the data across!!
 - Once you are happy, to destroy everything run
-``docker-compose -f configs/kafka-migration.yml  stop && docker-compose -f configs/kafka-migration.yml  rm``  
-and  
-``boot2docker restart``  
+``docker-compose -f configs/kafka-migration.yml  stop && docker-compose -f configs/kafka-migration.yml  rm``
+and
+``docker-machine restart default``
 
 ## THINGS TO NOTE
-1) Whilst this migration is being done, it's essential that new topics aren't being created.  
-2) You really have to wait for all the data/partitions to have been moved from brokers 1 2 3 before shutting them down, this can take a while.  
-
+1) Whilst this migration is being done, it's essential that new topics aren't being created.
+2) You really have to wait for all the data/partitions to have been moved from brokers 1 2 3 before shutting them down, this can take a while.


### PR DESCRIPTION
Update documentation to replace boot2docker with docker-machine. It follows PR https://github.com/FundingCircle/kafka-compose/pull/8
